### PR TITLE
feat: implement LRU cache system with namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,7 @@ $salesReport = memoize()->memo(
 <tr><td width="30%"><strong>Method</strong></td><td><strong>Description</strong></td></tr>
 <tr><td>
 
-```php
-memo(?string $key, callable $callback)
-```
+**memo(?string $key, callable $callback)**
 
 </td><td>
 
@@ -187,9 +185,7 @@ memo(?string $key, callable $callback)
 </td></tr>
 <tr><td>
 
-```php  
-once(callable $callback)
-```
+**once(callable $callback)**
 
 </td><td>
 
@@ -198,9 +194,7 @@ once(callable $callback)
 </td></tr>
 <tr><td>
 
-```php
-for(string $class)
-```
+**for(string $class)**
 
 </td><td>
 
@@ -215,37 +209,27 @@ for(string $class)
 <tr><td width="30%"><strong>Method</strong></td><td><strong>Description</strong></td></tr>
 <tr><td>
 
-```php
-has(string $key): bool
-```
+**has(string $key): bool**
 
 </td><td>Check if a key exists in cache</td></tr>
 <tr><td>
 
-```php
-forget(string $key): bool  
-```
+**forget(string $key): bool**
 
 </td><td>Remove specific key from cache</td></tr>
 <tr><td>
 
-```php
-flush(): void
-```
+**flush(): void**
 
 </td><td>Clear all cached values</td></tr>
 <tr><td>
 
-```php
-setMaxSize(?int $maxSize): void
-```
+**setMaxSize(?int $maxSize): void**
 
 </td><td>Set maximum entries (LRU eviction)</td></tr>
 <tr><td>
 
-```php
-getStats(): array
-```
+**getStats(): array**
 
 </td><td>Get detailed cache statistics</td></tr>
 </table>

--- a/src/Services/MemoEntry.php
+++ b/src/Services/MemoEntry.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tomloprod\Memoize\Services;
+
+final class MemoEntry
+{
+    public ?MemoEntry $previous = null;
+
+    public ?MemoEntry $next = null;
+
+    private int $hits = 0;
+
+    private int $lastAccess;
+
+    public function __construct(
+        private readonly ?string $namespace,
+        private readonly string $key,
+        private readonly mixed $value
+    ) {
+        $this->lastAccess = hrtime(true);
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getHits(): int
+    {
+        return $this->hits;
+    }
+
+    public function getLastAccess(): int
+    {
+        return $this->lastAccess;
+    }
+
+    public function markAsAccessed(): void
+    {
+        $this->hits++;
+        $this->lastAccess = hrtime(true);
+    }
+
+    /**
+     * Detach this entry from the doubly linked list.
+     */
+    public function detach(): void
+    {
+        if ($this->previous instanceof self) {
+            $this->previous->next = $this->next;
+        }
+
+        if ($this->next instanceof self) {
+            $this->next->previous = $this->previous;
+        }
+
+        $this->previous = null;
+        $this->next = null;
+    }
+}

--- a/src/Services/MemoizeManager.php
+++ b/src/Services/MemoizeManager.php
@@ -5,13 +5,22 @@ declare(strict_types=1);
 namespace Tomloprod\Memoize\Services;
 
 use Exception;
+use InvalidArgumentException;
 
 final class MemoizeManager
 {
     private static MemoizeManager $instance;
 
-    /** @var array<string, mixed> */
+    /** @var array<string, MemoEntry> */
     private array $memoizedValues = [];
+
+    private ?int $maxSize = null;
+
+    private ?MemoEntry $head = null;
+
+    private ?MemoEntry $tail = null;
+
+    private ?string $namespace = null;
 
     private function __construct() {}
 
@@ -38,23 +47,69 @@ final class MemoizeManager
     }
 
     /**
+     * Set a namespace for the next memoization operation.
+     *
+     * @param  string  $class  The class name to use as namespace
+     */
+    public function for(string $class): self
+    {
+        $this->namespace = $class;
+
+        return $this;
+    }
+
+    /**
      * Memoize cache values in memory during a single request or job execution.
      * This prevents repeated cache hits within the same execution, significantly
      * improving performance.
      *
-     * @param  string  $key  Cache key
+     * @param  string|null  $key  Cache key (null returns null when namespace is set)
      * @param  callable  $callback  Function to execute if value is not memoized
      */
-    public function memo(string $key, callable $callback): mixed
+    public function memo(?string $key, callable $callback): mixed
     {
+        // Handle null key with namespace: return null without executing callback
+        if ($key === null && $this->namespace !== null) {
+            $this->namespace = null;
+
+            return null;
+        }
+
+        // Handle null key without namespace: throw exception (backward compatibility)
+        if ($key === null) {
+            throw new InvalidArgumentException('Key cannot be null when no namespace is set');
+        }
+
+        // Build namespaced key if namespace is set
+        $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
+
         // Return memoized value if exists
-        if (array_key_exists($key, $this->memoizedValues)) {
-            return $this->memoizedValues[$key];
+        if (array_key_exists($namespacedKey, $this->memoizedValues)) {
+
+            $entry = $this->memoizedValues[$namespacedKey];
+
+            $entry->markAsAccessed();
+
+            $this->moveToHead($entry);
+
+            $this->namespace = null;
+
+            return $entry->getValue();
         }
 
         // Execute callback and memoize the result
         $value = $callback();
-        $this->memoizedValues[$key] = $value;
+
+        $entry = new MemoEntry($this->namespace, $key, $value);
+        $entry->markAsAccessed();
+
+        $this->memoizedValues[$namespacedKey] = $entry;
+
+        $this->addToHead($entry);
+
+        $this->enforceLRU();
+
+        $this->namespace = null;
 
         return $value;
     }
@@ -67,11 +122,22 @@ final class MemoizeManager
      */
     public function forget(string $key): bool
     {
-        if (array_key_exists($key, $this->memoizedValues)) {
-            unset($this->memoizedValues[$key]);
+        $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
+
+        if (array_key_exists($namespacedKey, $this->memoizedValues)) {
+
+            $entry = $this->memoizedValues[$namespacedKey];
+
+            unset($this->memoizedValues[$namespacedKey]);
+
+            $this->removeFromList($entry);
+
+            $this->namespace = null;
 
             return true;
         }
+
+        $this->namespace = null;
 
         return false;
     }
@@ -82,6 +148,9 @@ final class MemoizeManager
     public function flush(): void
     {
         $this->memoizedValues = [];
+        $this->head = null;
+        $this->tail = null;
+        $this->namespace = null;
     }
 
     /**
@@ -92,17 +161,23 @@ final class MemoizeManager
      */
     public function has(string $key): bool
     {
-        return array_key_exists($key, $this->memoizedValues);
+        $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
+
+        $result = array_key_exists($namespacedKey, $this->memoizedValues);
+
+        $this->namespace = null;
+
+        return $result;
     }
 
     /**
-     * Get all memoized keys.
+     * Get all memoized entries.
      *
-     * @return array<string> Array of all cached keys
+     * @return array<string, MemoEntry> Array of namespacedKey => MemoEntry
      */
-    public function keys(): array
+    public function getMemoizedValues(): array
     {
-        return array_keys($this->memoizedValues);
+        return $this->memoizedValues;
     }
 
     /**
@@ -126,5 +201,164 @@ final class MemoizeManager
 
             return $result;
         };
+    }
+
+    /**
+     * Set the maximum size of entries (LRU).
+     */
+    public function setMaxSize(?int $maxSize): void
+    {
+        $this->maxSize = $maxSize;
+
+        $this->enforceLRU();
+    }
+
+    /**
+     * Get the maximum size currently.
+     */
+    public function getMaxSize(): ?int
+    {
+        return $this->maxSize;
+    }
+
+    /**
+     * Get stats of the cache.
+     *
+     * @return array{
+     *     size: int,
+     *     maxSize: int|null,
+     *     head: array{
+     *         key: string|null,
+     *         time: int|null,
+     *         hits: int,
+     *     },
+     *     tail: array{
+     *         key: string|null,
+     *         time: int|null,
+     *         hits: int,
+     *     },
+     * }
+     */
+    public function getStats(): array
+    {
+        $headKey = null;
+        if ($this->head instanceof MemoEntry) {
+            $namespace = $this->head->getNamespace();
+            $key = $this->head->getKey();
+            $headKey = $this->buildNamespacedKey($namespace, $key);
+        }
+
+        $tailKey = null;
+        if ($this->tail instanceof MemoEntry) {
+            $namespace = $this->tail->getNamespace();
+            $key = $this->tail->getKey();
+            $tailKey = $this->buildNamespacedKey($namespace, $key);
+        }
+
+        return [
+            'size' => count($this->memoizedValues),
+            'maxSize' => $this->maxSize,
+            'head' => [
+                'key' => $headKey,
+                'time' => $this->head?->getLastAccess(),
+                'hits' => $this->head?->getHits() ?? 0,
+            ],
+            'tail' => [
+                'key' => $tailKey,
+                'time' => $this->tail?->getLastAccess(),
+                'hits' => $this->tail?->getHits() ?? 0,
+            ],
+        ];
+    }
+
+    /**
+     * Apply the LRU strategy if there is a limit.
+     */
+    private function enforceLRU(): void
+    {
+        if ($this->maxSize === null || count($this->memoizedValues) <= $this->maxSize) {
+            return;
+        }
+
+        // Remove from the end (least recently used) until the limit is met
+        while (count($this->memoizedValues) > $this->maxSize) {
+            $this->removeTail();
+        }
+    }
+
+    /**
+     * Add an entry to the beginning of the list (most recently used).
+     */
+    private function addToHead(MemoEntry $entry): void
+    {
+        $entry->detach();
+
+        $entry->next = $this->head;
+        $entry->previous = null;
+
+        if ($this->head instanceof MemoEntry) {
+            $this->head->previous = $entry;
+        }
+
+        $this->head = $entry;
+
+        if (! $this->tail instanceof MemoEntry) {
+            $this->tail = $entry;
+        }
+    }
+
+    // $unidadMedida = memoize()
+    // ->for(TipoUnidadMedida::class)
+    // ->skipIfNullKey()        // no ejecuta si key es null
+    // ->default(null)
+    // ->remember($this->unidad_medida_id, fn() => $this->unidadMedida);
+
+    /**
+     * Move an existing entry to the beginning of the list.
+     */
+    private function moveToHead(MemoEntry $entry): void
+    {
+        $this->removeFromList($entry);
+        $this->addToHead($entry);
+    }
+
+    /**
+     * Remove an entry from the list.
+     */
+    private function removeFromList(MemoEntry $entry): void
+    {
+        if ($entry === $this->head) {
+            $this->head = $entry->next;
+        }
+
+        if ($entry === $this->tail) {
+            $this->tail = $entry->previous;
+        }
+
+        $entry->detach();
+    }
+
+    /**
+     * Remove and return the entry from the end of the list (least recently used).
+     */
+    private function removeTail(): void
+    {
+        if (! $this->tail instanceof MemoEntry) {
+            return;
+        }
+
+        $lastEntry = $this->tail;
+
+        unset($this->memoizedValues[$lastEntry->getKey()]);
+
+        $this->removeFromList($lastEntry);
+    }
+
+    /**
+     * Build a namespaced key from namespace and key components.
+     */
+    private function buildNamespacedKey(?string $namespace, string $key): string
+    {
+        return $namespace !== null ? $namespace.'::'.$key : $key;
     }
 }

--- a/src/Support/Facades/Memoize.php
+++ b/src/Support/Facades/Memoize.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Tomloprod\Memoize\Support\Facades;
 
+use Tomloprod\Memoize\Services\MemoEntry;
 use Tomloprod\Memoize\Services\MemoizeManager;
 
 /**
- * @method static mixed memo(string $key, callable $callback)
+ * @method static mixed memo(?string $key, callable $callback)
  * @method static bool forget(string $key)
  * @method static void flush()
  * @method static bool has(string $key)
- * @method static array<string> keys()
+ * @method static array<string, MemoEntry> getMemoizedValues()
  * @method static callable once(callable $fn)
+ * @method static void setMaxSize(?int $maxSize)
+ * @method static ?int getMaxSize()
+ * @method static array getStats()
+ * @method static self for(string $class)
  */
 final class Memoize
 {

--- a/tests/Services/MemoEntryTest.php
+++ b/tests/Services/MemoEntryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use Tomloprod\Memoize\Services\MemoEntry;
+
+test('creates entry with correct key and value', function (): void {
+    $entry = new MemoEntry(null, 'test_key', 'test_value');
+
+    expect($entry->getNamespace())->toBeNull();
+    expect($entry->getKey())->toBe('test_key');
+    expect($entry->getValue())->toBe('test_value');
+});
+
+test('creates entry with namespace', function (): void {
+    $entry = new MemoEntry('App\\Models\\User', 'test_key', 'test_value');
+
+    expect($entry->getNamespace())->toBe('App\\Models\\User');
+    expect($entry->getKey())->toBe('test_key');
+    expect($entry->getValue())->toBe('test_value');
+});
+
+test('tracks hits correctly', function (): void {
+    $entry = new MemoEntry(null, 'test_key', 'test_value');
+
+    expect($entry->getHits())->toBe(0);
+
+    $entry->markAsAccessed();
+    expect($entry->getHits())->toBe(1);
+
+    $entry->markAsAccessed();
+    expect($entry->getHits())->toBe(2);
+
+    $entry->markAsAccessed();
+    expect($entry->getHits())->toBe(3);
+});
+
+test('tracks last access time', function (): void {
+    $timeBefore = hrtime(true);
+    $entry = new MemoEntry(null, 'test_key', 'test_value');
+    $timeAfter = hrtime(true);
+
+    $lastAccess = $entry->getLastAccess();
+    expect($lastAccess)->toBeGreaterThanOrEqual($timeBefore);
+    expect($lastAccess)->toBeLessThanOrEqual($timeAfter);
+
+    usleep(1000);
+
+    $entry->markAsAccessed();
+    $newLastAccess = $entry->getLastAccess();
+    expect($newLastAccess)->toBeGreaterThan($lastAccess);
+});
+
+test('detach works with single entry', function (): void {
+    $entry = new MemoEntry(null, 'test_key', 'test_value');
+
+    $entry->detach();
+
+    expect($entry->previous)->toBeNull();
+    expect($entry->next)->toBeNull();
+});
+
+test('detach works with linked list', function (): void {
+    $entry1 = new MemoEntry(null, 'key1', 'value1');
+    $entry2 = new MemoEntry(null, 'key2', 'value2');
+    $entry3 = new MemoEntry(null, 'key3', 'value3');
+
+    $entry1->next = $entry2;
+    $entry2->previous = $entry1;
+    $entry2->next = $entry3;
+    $entry3->previous = $entry2;
+
+    $entry2->detach();
+
+    expect($entry2->previous)->toBeNull();
+    expect($entry2->next)->toBeNull();
+
+    expect($entry1->next)->toBe($entry3);
+    expect($entry3->previous)->toBe($entry1);
+});
+
+test('detach works when entry is at the beginning', function (): void {
+    $entry1 = new MemoEntry(null, 'key1', 'value1');
+    $entry2 = new MemoEntry(null, 'key2', 'value2');
+
+    $entry1->next = $entry2;
+    $entry2->previous = $entry1;
+
+    $entry1->detach();
+
+    expect($entry1->previous)->toBeNull();
+    expect($entry1->next)->toBeNull();
+    expect($entry2->previous)->toBeNull();
+});
+
+test('detach works when entry is at the end', function (): void {
+    $entry1 = new MemoEntry(null, 'key1', 'value1');
+    $entry2 = new MemoEntry(null, 'key2', 'value2');
+
+    $entry1->next = $entry2;
+    $entry2->previous = $entry1;
+
+    $entry2->detach();
+
+    expect($entry2->previous)->toBeNull();
+    expect($entry2->next)->toBeNull();
+    expect($entry1->next)->toBeNull();
+});
+
+test('works with different value types', function (): void {
+    $arrayEntry = new MemoEntry(null, 'array_key', ['data' => 'value']);
+    expect($arrayEntry->getValue())->toBe(['data' => 'value']);
+
+    $objectEntry = new MemoEntry(null, 'object_key', (object) ['prop' => 'value']);
+    expect($objectEntry->getValue())->toEqual((object) ['prop' => 'value']);
+
+    $nullEntry = new MemoEntry(null, 'null_key', null);
+    expect($nullEntry->getValue())->toBeNull();
+
+    $intEntry = new MemoEntry(null, 'int_key', 42);
+    expect($intEntry->getValue())->toBe(42);
+
+    $boolEntry = new MemoEntry(null, 'bool_key', true);
+    expect($boolEntry->getValue())->toBe(true);
+});


### PR DESCRIPTION
### Changes
- Add `MemoEntry` class with doubly linked list for efficient LRU operations
- Implement namespace support via `for()` method for better cache organization
- Add configurable maximum cache size with automatic eviction
- Add hit tracking and access time recording for performance analysis

### Breaking changes:
- `memo()` method now accepts nullable key for namespace scenarios
- `keys()` method replaced with getMemoizedValues() returning MemoEntry objects