### PR TITLE
feat: add runtime flags for dynamic behavior control

### DIFF
--- a/src/Concerns/HasFlags.php
+++ b/src/Concerns/HasFlags.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tomloprod\Memoize\Concerns;
+
+/**
+ * Trait for handling flag-related functionalities.
+ */
+trait HasFlags
+{
+    /** @var array<string, bool> */
+    private array $enabledFlags = [];
+
+    /**
+     * Enable a specific flag.
+     */
+    public function enableFlag(string $flag): self
+    {
+        $this->enabledFlags[$flag] = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable a specific flag.
+     */
+    public function disableFlag(string $flag): self
+    {
+        unset($this->enabledFlags[$flag]);
+
+        return $this;
+    }
+
+    /**
+     * Toggle the state of a flag (enabled/disabled).
+     */
+    public function toggleFlag(string $flag): self
+    {
+        if (isset($this->enabledFlags[$flag])) {
+            unset($this->enabledFlags[$flag]);
+        } else {
+            $this->enabledFlags[$flag] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if a specific flag is enabled.
+     */
+    public function hasFlag(string $flag): bool
+    {
+        return isset($this->enabledFlags[$flag]);
+    }
+
+    /**
+     * Get all currently enabled flags.
+     *
+     * @return array<string, bool> Associative array with enabled flags
+     */
+    public function getFlags(): array
+    {
+        return $this->enabledFlags;
+    }
+
+    /**
+     * Enable multiple flags at once.
+     *
+     * @param  array<string>  $flags  Array of flag names to enable
+     */
+    public function enableFlags(array $flags): self
+    {
+        foreach ($flags as $flag) {
+            $this->enabledFlags[$flag] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable multiple flags at once.
+     *
+     * @param  array<string>  $flags  Array of flag names to disable
+     */
+    public function disableFlags(array $flags): self
+    {
+        foreach ($flags as $flag) {
+            unset($this->enabledFlags[$flag]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear all enabled flags.
+     */
+    public function clearFlags(): self
+    {
+        $this->enabledFlags = [];
+
+        return $this;
+    }
+
+    /**
+     * Check if at least one of the specified flags is enabled.
+     *
+     * @param  array<string>  $flags  Array of flag names to check
+     */
+    public function hasAnyFlag(array $flags): bool
+    {
+        foreach ($flags as $flag) {
+            if (isset($this->enabledFlags[$flag])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if all specified flags are enabled.
+     *
+     * @param  array<string>  $flags  Array of flag names to check
+     */
+    public function hasAllFlags(array $flags): bool
+    {
+        foreach ($flags as $flag) {
+            if (! isset($this->enabledFlags[$flag])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Services/MemoizeManager.php
+++ b/src/Services/MemoizeManager.php
@@ -6,9 +6,12 @@ namespace Tomloprod\Memoize\Services;
 
 use Exception;
 use InvalidArgumentException;
+use Tomloprod\Memoize\Concerns\HasFlags;
 
 final class MemoizeManager
 {
+    use HasFlags;
+
     private static MemoizeManager $instance;
 
     /** @var array<string, MemoEntry> */

--- a/src/Support/Facades/Memoize.php
+++ b/src/Support/Facades/Memoize.php
@@ -18,6 +18,16 @@ use Tomloprod\Memoize\Services\MemoizeManager;
  * @method static ?int getMaxSize()
  * @method static array getStats()
  * @method static self for(string $class)
+ * @method static self enableFlag(string $flag)
+ * @method static self disableFlag(string $flag)
+ * @method static self toggleFlag(string $flag)
+ * @method static bool hasFlag(string $flag)
+ * @method static array<string, bool> getFlags()
+ * @method static self enableFlags(array $flags)
+ * @method static self disableFlags(array $flags)
+ * @method static self clearFlags()
+ * @method static bool hasAnyFlag(array $flags)
+ * @method static bool hasAllFlags(array $flags)
  */
 final class Memoize
 {

--- a/tests/Concerns/HasFlagsTest.php
+++ b/tests/Concerns/HasFlagsTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use Tomloprod\Memoize\Services\MemoizeManager;
+
+beforeEach(function (): void {
+    $this->manager = MemoizeManager::instance();
+    $this->manager->flush();
+    $this->manager->clearFlags();
+});
+
+test('enableFlag enables a specific flag', function (): void {
+    $result = $this->manager->enableFlag('test_flag');
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('test_flag'))->toBeTrue()
+        ->and($this->manager->getFlags())->toBe(['test_flag' => true]);
+});
+
+test('disableFlag disables a specific flag', function (): void {
+    $this->manager->enableFlag('test_flag');
+    $result = $this->manager->disableFlag('test_flag');
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('test_flag'))->toBeFalse()
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('disableFlag returns instance when flag does not exist', function (): void {
+    $result = $this->manager->disableFlag('non_existent_flag');
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('toggleFlag enables flag when disabled', function (): void {
+    $result = $this->manager->toggleFlag('test_flag');
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('test_flag'))->toBeTrue()
+        ->and($this->manager->getFlags())->toBe(['test_flag' => true]);
+});
+
+test('toggleFlag disables flag when enabled', function (): void {
+    $this->manager->enableFlag('test_flag');
+    $result = $this->manager->toggleFlag('test_flag');
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('test_flag'))->toBeFalse()
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('hasFlag returns true when flag is enabled', function (): void {
+    $this->manager->enableFlag('test_flag');
+
+    expect($this->manager->hasFlag('test_flag'))->toBeTrue();
+});
+
+test('hasFlag returns false when flag is disabled', function (): void {
+    expect($this->manager->hasFlag('test_flag'))->toBeFalse();
+});
+
+test('getFlags returns all enabled flags', function (): void {
+    $this->manager->enableFlag('flag1')
+        ->enableFlag('flag2')
+        ->enableFlag('flag3');
+
+    $expected = [
+        'flag1' => true,
+        'flag2' => true,
+        'flag3' => true,
+    ];
+
+    expect($this->manager->getFlags())->toBe($expected);
+});
+
+test('getFlags returns empty array when no flags are enabled', function (): void {
+    expect($this->manager->getFlags())->toBe([]);
+});
+
+test('enableFlags enables multiple flags at once', function (): void {
+    $flags = ['flag1', 'flag2', 'flag3'];
+    $result = $this->manager->enableFlags($flags);
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('flag1'))->toBeTrue()
+        ->and($this->manager->hasFlag('flag2'))->toBeTrue()
+        ->and($this->manager->hasFlag('flag3'))->toBeTrue()
+        ->and($this->manager->getFlags())->toBe([
+            'flag1' => true,
+            'flag2' => true,
+            'flag3' => true,
+        ]);
+});
+
+test('enableFlags works with empty array', function (): void {
+    $result = $this->manager->enableFlags([]);
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('disableFlags disables multiple flags at once', function (): void {
+    $this->manager->enableFlag('flag1')
+        ->enableFlag('flag2')
+        ->enableFlag('flag3')
+        ->enableFlag('flag4');
+
+    $result = $this->manager->disableFlags(['flag1', 'flag3']);
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('flag1'))->toBeFalse()
+        ->and($this->manager->hasFlag('flag2'))->toBeTrue()
+        ->and($this->manager->hasFlag('flag3'))->toBeFalse()
+        ->and($this->manager->hasFlag('flag4'))->toBeTrue()
+        ->and($this->manager->getFlags())->toBe([
+            'flag2' => true,
+            'flag4' => true,
+        ]);
+});
+
+test('disableFlags works with empty array', function (): void {
+    $this->manager->enableFlag('flag1');
+    $result = $this->manager->disableFlags([]);
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('flag1'))->toBeTrue();
+});
+
+test('disableFlags works with non-existent flags', function (): void {
+    $this->manager->enableFlag('flag1');
+    $result = $this->manager->disableFlags(['flag1', 'non_existent']);
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->hasFlag('flag1'))->toBeFalse()
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('clearFlags removes all enabled flags', function (): void {
+    $this->manager->enableFlag('flag1')
+        ->enableFlag('flag2')
+        ->enableFlag('flag3');
+
+    $result = $this->manager->clearFlags();
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->getFlags())->toBe([])
+        ->and($this->manager->hasFlag('flag1'))->toBeFalse()
+        ->and($this->manager->hasFlag('flag2'))->toBeFalse()
+        ->and($this->manager->hasFlag('flag3'))->toBeFalse();
+});
+
+test('clearFlags works when no flags are enabled', function (): void {
+    $result = $this->manager->clearFlags();
+
+    expect($result)->toBe($this->manager)
+        ->and($this->manager->getFlags())->toBe([]);
+});
+
+test('hasAnyFlag returns true when at least one flag is enabled', function (): void {
+    $this->manager->enableFlag('flag2');
+
+    expect($this->manager->hasAnyFlag(['flag1', 'flag2', 'flag3']))->toBeTrue();
+});
+
+test('hasAnyFlag returns false when no flags are enabled', function (): void {
+    expect($this->manager->hasAnyFlag(['flag1', 'flag2', 'flag3']))->toBeFalse();
+});
+
+test('hasAnyFlag returns false with empty array', function (): void {
+    $this->manager->enableFlag('flag1');
+
+    expect($this->manager->hasAnyFlag([]))->toBeFalse();
+});
+
+test('hasAnyFlag returns true when first flag is enabled', function (): void {
+    $this->manager->enableFlag('flag1');
+
+    expect($this->manager->hasAnyFlag(['flag1', 'flag2']))->toBeTrue();
+});
+
+test('hasAllFlags returns true when all specified flags are enabled', function (): void {
+    $this->manager->enableFlag('flag1')
+        ->enableFlag('flag2')
+        ->enableFlag('flag3');
+
+    expect($this->manager->hasAllFlags(['flag1', 'flag2']))->toBeTrue();
+});
+
+test('hasAllFlags returns false when some flags are missing', function (): void {
+    $this->manager->enableFlag('flag1');
+
+    expect($this->manager->hasAllFlags(['flag1', 'flag2']))->toBeFalse();
+});
+
+test('hasAllFlags returns false when no flags are enabled', function (): void {
+    expect($this->manager->hasAllFlags(['flag1', 'flag2']))->toBeFalse();
+});
+
+test('hasAllFlags returns true with empty array', function (): void {
+    expect($this->manager->hasAllFlags([]))->toBeTrue();
+});
+
+test('hasAllFlags returns false when first flag is missing', function (): void {
+    $this->manager->enableFlag('flag2');
+
+    expect($this->manager->hasAllFlags(['flag1', 'flag2']))->toBeFalse();
+});
+
+test('complex flag operations work together', function (): void {
+    // Test a complex scenario combining multiple operations
+    $this->manager
+        ->enableFlags(['flag1', 'flag2', 'flag3'])
+        ->disableFlag('flag2')
+        ->toggleFlag('flag4')
+        ->toggleFlag('flag1');
+
+    expect($this->manager->getFlags())->toBe([
+        'flag3' => true,
+        'flag4' => true,
+    ])
+        ->and($this->manager->hasAnyFlag(['flag1', 'flag3']))->toBeTrue()
+        ->and($this->manager->hasAllFlags(['flag3', 'flag4']))->toBeTrue()
+        ->and($this->manager->hasAllFlags(['flag1', 'flag3']))->toBeFalse();
+});


### PR DESCRIPTION
- Add HasFlags trait with enable/disable/toggle flag methods
- Implement flag checking methods (`hasFlag`, `hasAnyFlag`, `hasAllFlags`)
- Add batch operations for multiple flags (`enableFlags`, `disableFlags`)
- Include clearFlags method to reset all flags

This allows conditional behavior control during execution without external configuration, perfect for testing, feature toggles, and environment-specific behavior.