### PR TITLE
feat: add support for scalar key types in memoization methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can also not use namespaces and just memoize keys.
 // Expensive API call cached by key
 $weather = memoize()->memo(
     'weather_london', 
-    fn() => Http::get('api.weather.com/london'->json()
+    fn() => Http::get('api.weather.com/london')->json()
 );
 
 // Database query with dynamic key
@@ -176,7 +176,7 @@ $salesReport = memoize()->memo(
 <tr><td width="30%"><strong>Method</strong></td><td><strong>Description</strong></td></tr>
 <tr><td>
 
-**memo(?string $key, callable $callback)**
+**memo(string|int|float|null $key, callable $callback)**
 
 </td><td>
 
@@ -209,12 +209,12 @@ $salesReport = memoize()->memo(
 <tr><td width="30%"><strong>Method</strong></td><td><strong>Description</strong></td></tr>
 <tr><td>
 
-**has(string $key): bool**
+**has(string|int|float $key): bool**
 
 </td><td>Check if a key exists in cache</td></tr>
 <tr><td>
 
-**forget(string $key): bool**
+**forget(string|int|float $key): bool**
 
 </td><td>Remove specific key from cache</td></tr>
 <tr><td>

--- a/src/Services/MemoizeManager.php
+++ b/src/Services/MemoizeManager.php
@@ -63,22 +63,25 @@ final class MemoizeManager
      * This prevents repeated cache hits within the same execution, significantly
      * improving performance.
      *
-     * @param  string|null  $key  Cache key (null returns null when namespace is set)
+     * @param  string|int|float|null  $key  Cache key (null returns null when namespace is set)
      * @param  callable  $callback  Function to execute if value is not memoized
      */
-    public function memo(?string $key, callable $callback): mixed
+    public function memo(string|int|float|null $key, callable $callback): mixed
     {
         // Handle null key with namespace: return null without executing callback
-        if ($key === null && $this->namespace !== null) {
+        if (($key === null || $key === '') && $this->namespace !== null) {
             $this->namespace = null;
 
             return null;
         }
 
         // Handle null key without namespace: throw exception (backward compatibility)
-        if ($key === null) {
+        if ($key === null || $key === '') {
             throw new InvalidArgumentException('Key cannot be null when no namespace is set');
         }
+
+        // Convert key to string for consistent handling
+        $key = (string) $key;
 
         // Build namespaced key if namespace is set
         $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
@@ -117,12 +120,12 @@ final class MemoizeManager
     /**
      * Remove a specific memoized value by key.
      *
-     * @param  string  $key  Cache key to remove
+     * @param  string|int|float  $key  Cache key to remove
      * @return bool True if the key existed and was removed, false otherwise
      */
-    public function forget(string $key): bool
+    public function forget(string|int|float $key): bool
     {
-        $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
+        $namespacedKey = $this->buildNamespacedKey($this->namespace, (string) $key);
 
         if (array_key_exists($namespacedKey, $this->memoizedValues)) {
 
@@ -156,12 +159,12 @@ final class MemoizeManager
     /**
      * Check if a key exists in the memoized cache.
      *
-     * @param  string  $key  Cache key to check
+     * @param  string|int|float  $key  Cache key to check
      * @return bool True if the key exists, false otherwise
      */
-    public function has(string $key): bool
+    public function has(string|int|float $key): bool
     {
-        $namespacedKey = $this->buildNamespacedKey($this->namespace, $key);
+        $namespacedKey = $this->buildNamespacedKey($this->namespace, (string) $key);
 
         $result = array_key_exists($namespacedKey, $this->memoizedValues);
 

--- a/src/Support/Facades/Memoize.php
+++ b/src/Support/Facades/Memoize.php
@@ -8,10 +8,10 @@ use Tomloprod\Memoize\Services\MemoEntry;
 use Tomloprod\Memoize\Services\MemoizeManager;
 
 /**
- * @method static mixed memo(?string $key, callable $callback)
- * @method static bool forget(string $key)
+ * @method static mixed memo(string|int|float|null $key, callable $callback)
+ * @method static bool forget(string|int|float $key)
  * @method static void flush()
- * @method static bool has(string $key)
+ * @method static bool has(string|int|float $key)
  * @method static array<string, MemoEntry> getMemoizedValues()
  * @method static callable once(callable $fn)
  * @method static void setMaxSize(?int $maxSize)


### PR DESCRIPTION
- Accept `string|int|float|null` keys in `memo()`, `forget()`, and `has()` methods
- Automatically convert numeric keys to string internally for consistency