### PR TITLE
feat: add enable/disable functionality for memoization

### DIFF
--- a/src/Support/Facades/Memoize.php
+++ b/src/Support/Facades/Memoize.php
@@ -28,6 +28,9 @@ use Tomloprod\Memoize\Services\MemoizeManager;
  * @method static self clearFlags()
  * @method static bool hasAnyFlag(array $flags)
  * @method static bool hasAllFlags(array $flags)
+ * @method static void disable()
+ * @method static void enable()
+ * @method static bool isEnabled()
  */
 final class Memoize
 {


### PR DESCRIPTION
- Add disable(), enable() and isEnabled() methods to MemoizeManager, to execute callbacks without caching when disabled
- Fix removeTail() to correctly use buildNamespacedKey()
- Add test for LRU behavior with namespaces